### PR TITLE
Handle the limit of p = 0 in p log2 p

### DIFF
--- a/antropy/entropy.py
+++ b/antropy/entropy.py
@@ -130,7 +130,7 @@ def perm_entropy(x, order=3, delay=1, normalize=False):
     _, c = np.unique(hashval, return_counts=True)
     # Use np.true_divide for Python 2 compatibility
     p = np.true_divide(c, c.sum())
-    pe = -np.multiply(p, np.log2(p)).sum()
+    pe = -_xlog2x(p).sum()
     if normalize:
         pe /= np.log2(factorial(order))
     return pe
@@ -246,7 +246,7 @@ def spectral_entropy(x, sf, method='fft', nperseg=None, normalize=False,
     elif method == 'welch':
         _, psd = welch(x, sf, nperseg=nperseg, axis=axis)
     psd_norm = psd / psd.sum(axis=axis, keepdims=True)
-    se = -(psd_norm * np.log2(psd_norm)).sum(axis=axis)
+    se = -_xlog2x(psd_norm).sum(axis=axis)
     if normalize:
         se /= np.log2(psd_norm.shape[axis])
     return se
@@ -359,7 +359,7 @@ def svd_entropy(x, order=3, delay=1, normalize=False):
     W = np.linalg.svd(mat, compute_uv=False)
     # Normalize the singular values
     W /= sum(W)
-    svd_e = -np.multiply(W, np.log2(W)).sum()
+    svd_e = -_xlog2x(W).sum()
     if normalize:
         svd_e /= np.log2(order)
     return svd_e
@@ -704,6 +704,15 @@ def _lz_complexity(binary_string):
         complexity += 1
 
     return complexity
+
+
+@np.vectorize
+def _xlog2x(x):
+    """Returns x log2 x if x is positive, 0 if x == 0, and np.nan
+    otherwise. This handles the case when the power spectrum density
+    takes any zero value.
+    """
+    return 0.0 if x == 0 else x * np.log2(x)
 
 
 def lziv_complexity(sequence, normalize=False):

--- a/antropy/tests/test_entropy.py
+++ b/antropy/tests/test_entropy.py
@@ -131,3 +131,12 @@ class TestEntropy(unittest.TestCase):
         # 2D data (avoid warning with flat line variance)
         assert_equal(aal(hjorth_params, axis=-1, arr=data[:-1, :]).T,
                      hjorth_params(data[:-1, :], axis=-1))
+
+    def test_xlog2x_handles_zero(self):
+        assert_equal(_xlog2x(0), 0)
+
+    def test_xlog2x_handles_array(self):
+        np.testing.assert_allclose(
+            _xlog2x(np.array([0, 0.25, 1, 2, 3, 4, -1])),
+            np.array([0, -0.5, 0, 2, 4.754887502163468, 8, np.nan])
+        )

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,12 @@
 What's new
 ##########
 
+v0.1.5 (June 2021)
+------------------
+
+a. Handle the limit of p = 0 in functions that evaluate the product p * log2(p), to give 0 instead of nan.
+
+
 v0.1.4 (April 2021)
 -------------------
 


### PR DESCRIPTION
This patch defines a helper function, _xlog2x(x), that calculates
x * log2(x) but handles the case x == 0 by returning 0 rather than nan.
This is needed if the power spectrum has any component that is exactly
zero: in particular, if the f = 0 component is zero.