### PR TITLE
Fix docstrings and rerun

### DIFF
--- a/notebooks/complexity_corr_membrane_potential.ipynb
+++ b/notebooks/complexity_corr_membrane_potential.ipynb
@@ -75,7 +75,7 @@
     "        Time point marking the start of stimulus input [ms]\n",
     "    t_stop : number\n",
     "        Time point marking the end of stimulus input [ms]\n",
-    "    kwargs : dict\n",
+    "    args : list\n",
     "        g_Na : number\n",
     "            Sodium (Na) maximum conductance [mS/cm^2]\n",
     "        g_K : number\n",
@@ -94,9 +94,13 @@
     "    Returns\n",
     "    -------\n",
     "    numpy.ndarray\n",
-    "        State variables dynamics of shape (`t.size`, 4).\n",
+    "        State variables dynamics of shape (`t.size`, 4)\n",
     "    \"\"\"\n",
     "    Vm, m, h, n = y0\n",
+    "    if args:\n",
+    "        g_Na, g_K, g_L, Cm, E_Na, E_K, E_L = args\n",
+    "    else:\n",
+    "        g_Na, g_K, g_L, Cm, E_Na, E_K, E_L = 120, 36, 0.3, 50, -77, -54.4\n",
     "    dVmdt = ((synaptic_current(t, A, t_start, t_stop)\n",
     "               - g_Na * m ** 3 * h * (Vm - E_Na)\n",
     "               - g_K * n ** 4 * (Vm - E_K)\n",
@@ -139,13 +143,13 @@
    "source": [
     "# Solve the ODE system\n",
     "I = synaptic_current(t, A, t_start, t_stop)\n",
-    "args = (A, t_start, t_stop, g_Na, g_K, g_L, Cm, E_Na, E_K, E_L)\n",
-    "Vm = odeint(hodgkin_huxley_model, y0, t, args=args)[:, 0]\n",
+    "params = (A, t_start, t_stop, g_Na, g_K, g_L, Cm, E_Na, E_K, E_L)\n",
+    "Vm = odeint(hodgkin_huxley_model, y0, t, args=params)[:, 0]\n",
     "\n",
-    "# Cunt the number of spikes...\n",
+    "# Count the number of spikes...\n",
     "thresh = -40\n",
     "n_spikes = find_peaks(Vm, height=thresh)[0].size\n",
-    "# ... and propose a sampling frequency\n",
+    "# ... and define a sampling frequency\n",
     "sf = (n_spikes + 1) * 2"
    ]
   },
@@ -171,7 +175,7 @@
     }
    ],
    "source": [
-    "# Generate 100 voltage traces with increasing noise...\n",
+    "# Generate 100 voltage traces with increasing noise\n",
     "np.random.seed(42)\n",
     "n_simulations = 100\n",
     "noise_factor = np.linspace(0, 10, n_simulations)\n",
@@ -180,20 +184,16 @@
     "for i in range(n_simulations):\n",
     "    traces[i] = Vm + noise_factor[i] * neural_noise[i, :]\n",
     "    \n",
-    "# ...and plot the first and last traces\n",
+    "# Plot the first and last voltage trace\n",
     "fig, ax = plt.subplots(2, 1, sharex=True, sharey=False,\n",
     "                       gridspec_kw={'height_ratios': [3, 1]}, figsize=(8, 5))\n",
-    "\n",
     "ax[0].plot(t, traces[0], label=f'noise factor = {noise_factor[0]}', zorder=2)\n",
     "ax[0].plot(t, traces[-1], label=f'noise factor = {noise_factor[-1]}', zorder=1)\n",
     "ax[0].set_ylabel('$V_m$ [mV]')\n",
     "ax[0].legend()\n",
-    "\n",
     "ax[1].plot(t, I, 'C2')\n",
     "ax[1].set_xlabel('$t$ [ms]')\n",
-    "ax[1].set_ylabel('$I$ [nA]')\n",
-    "\n",
-    "plt.show()"
+    "ax[1].set_ylabel('$I$ [nA]');"
    ]
   },
   {


### PR DESCRIPTION
Hi,

This PR fixes the following issues regarding the recent notebook:
* a few typos in comments;
* a docstring error in `hodgkin_huxley_model`, should be `args : list` instead of `kwargs : dict`, so from this:
```python
def hodgkin_huxley_model(y0, t, A, t_start, t_stop, *args):
    """Return the change in state variables of the neuron.

    Parameters
    ----------
    (...)
    kwargs : dict
        (...)
    """
```
to this:
```python
def hodgkin_huxley_model(y0, t, A, t_start, t_stop, *args):
    """Return the change in state variables of the neuron.

    Parameters
    ----------
    (...)
    args : list
        (...)
    """
```
* finally, I did some slight changes in visualization code to be more consistent with previous two notebooks.