### PR TITLE
Improve performance in `_xlog2x`

### DIFF
--- a/antropy/entropy.py
+++ b/antropy/entropy.py
@@ -5,7 +5,7 @@ from math import factorial, log
 from sklearn.neighbors import KDTree
 from scipy.signal import periodogram, welch
 
-from .utils import _embed, _xlog2x
+from .utils import _embed, _xlogx
 
 all = ['perm_entropy', 'spectral_entropy', 'svd_entropy', 'app_entropy',
        'sample_entropy', 'lziv_complexity', 'num_zerocross', 'hjorth_params']
@@ -129,7 +129,7 @@ def perm_entropy(x, order=3, delay=1, normalize=False):
     _, c = np.unique(hashval, return_counts=True)
     # Use np.true_divide for Python 2 compatibility
     p = np.true_divide(c, c.sum())
-    pe = -_xlog2x(p).sum()
+    pe = -_xlogx(p).sum()
     if normalize:
         pe /= np.log2(factorial(order))
     return pe
@@ -245,7 +245,7 @@ def spectral_entropy(x, sf, method='fft', nperseg=None, normalize=False,
     elif method == 'welch':
         _, psd = welch(x, sf, nperseg=nperseg, axis=axis)
     psd_norm = psd / psd.sum(axis=axis, keepdims=True)
-    se = -_xlog2x(psd_norm).sum(axis=axis)
+    se = -_xlogx(psd_norm).sum(axis=axis)
     if normalize:
         se /= np.log2(psd_norm.shape[axis])
     return se
@@ -358,7 +358,7 @@ def svd_entropy(x, order=3, delay=1, normalize=False):
     W = np.linalg.svd(mat, compute_uv=False)
     # Normalize the singular values
     W /= sum(W)
-    svd_e = -_xlog2x(W).sum()
+    svd_e = -_xlogx(W).sum()
     if normalize:
         svd_e /= np.log2(order)
     return svd_e

--- a/antropy/tests/test_entropy.py
+++ b/antropy/tests/test_entropy.py
@@ -7,7 +7,7 @@ from antropy import (perm_entropy, spectral_entropy, svd_entropy,
                      sample_entropy, app_entropy, lziv_complexity,
                      num_zerocross, hjorth_params)
 
-from antropy.utils import _xlog2x
+from antropy.utils import _xlogx
 
 np.random.seed(1234567)
 RANDOM_TS = np.random.rand(3000)
@@ -139,11 +139,29 @@ class TestEntropy(unittest.TestCase):
         assert_equal(aal(hjorth_params, axis=-1, arr=data[:-1, :]).T,
                      hjorth_params(data[:-1, :], axis=-1))
 
-    def test_xlog2x_handles_zero(self):
-        assert_equal(_xlog2x(0), 0)
+    def test_xlogx_handles_zero(self):
+        assert_equal(_xlogx(0), 0)
 
-    def test_xlog2x_handles_array(self):
+    def test_xlogx_handles_array(self):
         np.testing.assert_allclose(
-            _xlog2x(np.array([0, 0.25, 1, 2, 3, 4, -1])),
+            _xlogx(np.array([0, 0.25, 1, 2, 3, 4, -1])),
             np.array([0, -0.5, 0, 2, 4.754887502163468, 8, np.nan])
+        )
+
+    def test_xlogx_handles_2d_array(self):
+        np.testing.assert_allclose(
+            _xlogx(np.array([
+                [0, 0.25, 1, 2, 3, 4, -1],
+                [-1, 0, 3, 4, -1, 0, 3]
+            ])),
+            np.array([
+                [0, -0.5, 0, 2, 4.754887502163468, 8, np.nan],
+                [np.nan, 0, 4.754887502163468, 8, np.nan, 0, 4.754887502163468]
+            ])
+        )
+
+    def test_xlogx_accepts_other_base(self):
+        np.testing.assert_allclose(
+            _xlogx(np.array([0, 1, 3, 9, -1]), base=3),
+            np.array([0, 0, 3, 18, np.nan])
         )

--- a/antropy/utils.py
+++ b/antropy/utils.py
@@ -104,9 +104,10 @@ def _log_n(min_n, max_n, factor):
     return np.array(ns, dtype=np.int64)
 
 
+@jit(nopython=True)
 def _xlog2x(x):
     """Returns x log2 x if x is positive, 0 if x == 0, and np.nan
     otherwise. This handles the case when the power spectrum density
     takes any zero value.
     """
-    return np.nan_to_num(x * np.log2(x), nan=0.0)
+    return np.where(x == 0, 0, x * np.log2(x))

--- a/antropy/utils.py
+++ b/antropy/utils.py
@@ -104,10 +104,9 @@ def _log_n(min_n, max_n, factor):
     return np.array(ns, dtype=np.int64)
 
 
-@jit(nopython=True)
-def _xlog2x(x):
-    """Returns x log2 x if x is positive, 0 if x == 0, and np.nan
+def _xlogx(x, base=2):
+    """Returns x log_b x if x is positive, 0 if x == 0, and np.nan
     otherwise. This handles the case when the power spectrum density
     takes any zero value.
     """
-    return np.where(x == 0, 0, x * np.log2(x))
+    return np.where(x == 0, 0, x * np.log(x) / np.log(base))

--- a/antropy/utils.py
+++ b/antropy/utils.py
@@ -104,10 +104,9 @@ def _log_n(min_n, max_n, factor):
     return np.array(ns, dtype=np.int64)
 
 
-@np.vectorize
 def _xlog2x(x):
     """Returns x log2 x if x is positive, 0 if x == 0, and np.nan
     otherwise. This handles the case when the power spectrum density
     takes any zero value.
     """
-    return 0.0 if x == 0 else x * np.log2(x)
+    return np.nan_to_num(x * np.log2(x), nan=0.0)


### PR DESCRIPTION
Follow up to #3

Using np.nan_to_num is advantageous because it makes use of numpy's
vectorization, instead of 'if x == 0', which applies the test pointwise.