### PR TITLE
Prevent invalid operations in xlogx

### DIFF
--- a/antropy/utils.py
+++ b/antropy/utils.py
@@ -109,6 +109,7 @@ def _xlogx(x, base=2):
     otherwise. This handles the case when the power spectrum density
     takes any zero value.
     """
+    x = np.asarray(x)
     xlogx = np.zeros(x.shape)
     xlogx[x < 0] = np.nan
     valid = x > 0

--- a/antropy/utils.py
+++ b/antropy/utils.py
@@ -109,4 +109,8 @@ def _xlogx(x, base=2):
     otherwise. This handles the case when the power spectrum density
     takes any zero value.
     """
-    return np.where(x == 0, 0, x * np.log(x) / np.log(base))
+    xlogx = np.zeros(x.shape)
+    xlogx[x < 0] = np.nan
+    valid = x > 0
+    xlogx[valid] = x[valid] * np.log(x[valid]) / np.log(base)
+    return xlogx


### PR DESCRIPTION
Prevents performing log on zero or negative values, thus eliminating the runtime warnings and improving performance when those values are present.