### PR TITLE
Allow readonly arrays for higuchi_fd

### DIFF
--- a/antropy/fractal.py
+++ b/antropy/fractal.py
@@ -1,6 +1,6 @@
 """Fractal functions"""
 import numpy as np
-from numba import jit
+from numba import jit, types
 from math import log, floor
 
 from .entropy import num_zerocross
@@ -194,7 +194,7 @@ def katz_fd(x, axis=-1):
     return kfd
 
 
-@jit('float64(float64[:], int32)')
+@jit((types.Array(types.float64, 1, 'C', readonly=True), types.int32))
 def _higuchi_fd(x, kmax):
     """Utility function for `higuchi_fd`.
     """

--- a/antropy/tests/test_fractal.py
+++ b/antropy/tests/test_fractal.py
@@ -44,6 +44,10 @@ class TestEntropy(unittest.TestCase):
         """
         # Compare with MNE-features
         self.assertEqual(np.round(higuchi_fd(RANDOM_TS), 8), 1.9914198)
+        # Check if readonly arrays can be processed as well
+        x = RANDOM_TS.copy().astype(np.float64)
+        x.flags.writeable = False
+        self.assertEqual(np.round(higuchi_fd(x), 8), 1.9914198)
         higuchi_fd(list(RANDOM_TS), kmax=20)
 
     def test_detrended_fluctuation(self):


### PR DESCRIPTION
The current behavior of this method changes the datatype of `x` as `np.asarray` is a wrapper for `np.array` where `copy=False`. (see [here](https://stackoverflow.com/questions/14415741/what-is-the-difference-between-numpys-array-and-asarray-functions))

I believe that this is (kind of) unexpected behavior, e.g., a user would not expect that the datatype would change when calculating a feature. Therefore, I suggest giving the user the option of not changing the datatype by adding a `copy` flag to the `higuchi_fd` function parameters. By default this flag = False, resulting in the same behavior as now (i.e., datatype of `x` is changed).


When benchmarking the speed of the code, I observed no real difference. Perhaps we should even remove the flag and just use `np.array` instead of `np.asarray`?  

```python
In [11]: x = np.random.rand(10_000).astype("float32")

In [12]: %timeit ant.higuchi_fd(x)
246 µs ± 5.24 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [13]: x = np.random.rand(10_000).astype("float32")

In [14]: %timeit ant.higuchi_fd(x, copy=True)
242 µs ± 93.4 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```


PS: I really like the fast functions in this library :smile: 