### PR TITLE
modify the _embed function to fit the 2d input

### DIFF
--- a/antropy/utils.py
+++ b/antropy/utils.py
@@ -11,8 +11,8 @@ def _embed(x, order=3, delay=1):
 
     Parameters
     ----------
-    x : 1d-array
-        Time series, of shape (n_times)
+    x : 2d-array
+        Time series, of shape (signal_indice, n_times)
     order : int
         Embedding dimension (order).
     delay : int
@@ -20,20 +20,36 @@ def _embed(x, order=3, delay=1):
 
     Returns
     -------
-    embedded : ndarray
-        Embedded time-series, of shape (n_times - (order - 1) * delay, order)
+    embedded : 3D array
+        Embedded time-series, of shape (signal_indice, n_times - (order - 1) * delay, order_num) 
     """
-    N = len(x)
+    
+    N = x.shape[-1]
+    # define the singal length
+    
     if order * delay > N:
         raise ValueError("Error: order * delay should be lower than x.size")
     if delay < 1:
         raise ValueError("Delay has to be at least 1.")
     if order < 2:
         raise ValueError("Order has to be at least 2.")
-    Y = np.zeros((order, N - (order - 1) * delay))
+        
+    Y = []
+    # pre-defiend an empty list to store numpy.array (concatenate with a list is faster)
+    embed_signal_length = N - (order - 1) * delay
+    # define the new signal length
+    indice = [[(i * delay), (i * delay)] for i in range(order)]
+    # generate a list of slice indice on input signal
     for i in range(order):
-        Y[i] = x[(i * delay):(i * delay + Y.shape[1])]
-    return Y.T
+        # loop with the order
+        temp = x[:, indice[i][0]: indice[i][1]].reshape(-1, length, 1)
+        # slicing the signal with the indice of each order (vectorized operation)
+        Y.append(temp)
+        # append the sliced signal to list 
+        
+    Y = np.concatenate(Y, axis=-1)
+    # concatenate the sliced signal to a 3D array (signal_indice, n_times - (order - 1) * delay, order_num) 
+    return Y
 
 
 @jit('UniTuple(float64, 2)(float64[:], float64[:])', nopython=True)

--- a/antropy/utils.py
+++ b/antropy/utils.py
@@ -6,7 +6,7 @@ from math import log, floor
 all = ['_embed', '_linear_regression', '_log_n', '_xlog2x']
 
 
-def _embed_modified(x, order=3, delay=1):
+def _embed(x, order=3, delay=1):
     """Time-delay embedding.
 
     Parameters


### PR DESCRIPTION
modify the _embed funciton, so, it can take input as 2d array.
pre store the sliced signal into a list to accelerate concatenation operation.
pre define the indice of sliced signal to reduce the computing in loop.
add vectorized operation in loop to slice the signal for all input signal in one time.

performance:
1e3 signal with 1000 time point, order = 3, decay=1: 0.01s

1e4 signal with 1000 time point, order = 3, decay=1: 0.1s
1e4 signal with 1000 time point, order = 10, decay=1: 0.85s

1e5 signal with 1000 time point, order = 3, decay=1: 1.11s
1e5 signal with 1000 time point, order = 10, decay=1: 9.82s

5e5 signal with 1000 time point, order = 3, decay=1: 67s