### PR TITLE
make _embd be able to pass 1D and 2D array both (with benchmark comparsion)

### DIFF
--- a/antropy/utils.py
+++ b/antropy/utils.py
@@ -11,8 +11,7 @@ def _embed(x, order=3, delay=1):
 
     Parameters
     ----------
-    x : 1d-array
-        Time series, of shape (n_times)
+    x : 1D-array of shape (n_times) or 2D-array of shape (signal_indice, n_times)
     order : int
         Embedding dimension (order).
     delay : int
@@ -20,20 +19,55 @@ def _embed(x, order=3, delay=1):
 
     Returns
     -------
-    embedded : ndarray
+    embedded : 2D-array (if x is 1D)
         Embedded time-series, of shape (n_times - (order - 1) * delay, order)
+    embedded : 3D-array if (x is 2D)
+        Embedded time-series, of shape (signal_indice, n_times - (order - 1) * delay, order_num) 
     """
-    N = len(x)
+
+    assert type(order) == int, "order must be integer!"
+    # check order is int
+
+    N = x.shape[-1]
     if order * delay > N:
         raise ValueError("Error: order * delay should be lower than x.size")
     if delay < 1:
         raise ValueError("Delay has to be at least 1.")
     if order < 2:
         raise ValueError("Order has to be at least 2.")
-    Y = np.zeros((order, N - (order - 1) * delay))
-    for i in range(order):
-        Y[i] = x[(i * delay):(i * delay + Y.shape[1])]
-    return Y.T
+    # check parameters
+
+    if x.ndim == 1:
+    # pass 1D array
+
+        Y = np.zeros((order, N - (order - 1) * delay))
+        for i in range(order):
+            Y[i] = x[(i * delay):(i * delay + Y.shape[1])]
+        return Y.T
+
+    else:
+    # pass 2D array
+
+        Y = []
+        # pre-defiend an empty list to store numpy.array (concatenate with a list is faster)
+
+        embed_signal_length = N - (order - 1) * delay
+        # define the new signal length
+
+        indice = [[(i * delay), (i * delay+embed_signal_length)] for i in range(order)]
+        # generate a list of slice indice on input signal
+
+        for i in range(order):
+        # loop with the order
+            temp = x[:, indice[i][0]: indice[i][1]].reshape(-1, embed_signal_length, 1)
+            # slicing the signal with the indice of each order (vectorized operation)
+
+            Y.append(temp)
+            # append the sliced signal to list 
+
+        Y = np.concatenate(Y, axis=-1)
+        # concatenate the sliced signal to a 3D array (signal_indice, n_times - (order - 1) * delay, order_num) 
+        return Y
 
 
 @jit('UniTuple(float64, 2)(float64[:], float64[:])', nopython=True)


### PR DESCRIPTION
add one condition to detect the array dimension
if 1d array, follow the original function code and return 2d array
if 2d array, return 3d array (signals_number, embedded signal length, order)

Hi , I have fixed the function to be able pass 1d and 2d array both. The return would be 2d if you pass 1d as the original function. I think there is no problem here. Hoever, if you pass 2d array, the function will return 3d array and no function from 'antropy' can deal with it so far, becasue I have not modified other functions. 

Do you prefer to merge it after I have modified other entropy computing function to be able pass the result (3d array) from the modified function? It might takes lots of time to modified whole function in this package. 

[benchmark comparsion.xlsx](https://github.com/raphaelvallat/antropy/files/7909151/benchmark.comparsion.xlsx)
