### PR TITLE
Fixed division by zero in linear regresion function

### DIFF
--- a/antropy/tests/test_fractal.py
+++ b/antropy/tests/test_fractal.py
@@ -11,7 +11,12 @@ NORMAL_TS = np.random.normal(size=3000)
 RANDOM_TS_LONG = np.random.rand(6000)
 SF_TS = 100
 PURE_SINE = np.sin(2 * np.pi * 1 * np.arange(3000) / 100)
+PURE_SINE2 = np.sin(2 * np.pi * 1 * np.arange(12) / 8)
 ARANGE = np.arange(3000)
+PPG_SIGNAL = np.array([-4.18272436e-07, 4.29464204e-07, -5.14206643e-06, 1.66113061e-05, 2.80120692e-05, 8.83404336e-05, 1.98141181e-04, -2.88309770e-05,
+                       1.97888389e-04, -1.23435636e-03, -7.56440358e-04, -2.97200186e-03, -1.34446557e-03, 8.17779135e-04, 2.52697129e-03, 1.52477197e-02,
+                       6.17225675e-03, 2.33431348e-02, -1.14744448e-02, -9.02422108e-03, -4.83006717e-02, -6.78126099e-02, -2.59228720e-02, -5.89649339e-02,
+                       1.29395071e-01])
 
 # Concatenate 2D data
 data = np.vstack((RANDOM_TS, NORMAL_TS, PURE_SINE, ARANGE))
@@ -55,3 +60,4 @@ class TestEntropy(unittest.TestCase):
         """
         self.assertEqual(np.round(detrended_fluctuation(RANDOM_TS), 4), 0.4976)
         self.assertEqual(np.round(detrended_fluctuation(PURE_SINE), 4), 1.5848)
+        self.assertEqual(np.round(detrended_fluctuation(PPG_SIGNAL), 4), 0.0)

--- a/antropy/tests/test_fractal.py
+++ b/antropy/tests/test_fractal.py
@@ -11,7 +11,6 @@ NORMAL_TS = np.random.normal(size=3000)
 RANDOM_TS_LONG = np.random.rand(6000)
 SF_TS = 100
 PURE_SINE = np.sin(2 * np.pi * 1 * np.arange(3000) / 100)
-PURE_SINE2 = np.sin(2 * np.pi * 1 * np.arange(12) / 8)
 ARANGE = np.arange(3000)
 PPG_SIGNAL = np.array([-4.18272436e-07, 4.29464204e-07, -5.14206643e-06, 1.66113061e-05, 2.80120692e-05, 8.83404336e-05, 1.98141181e-04, -2.88309770e-05,
                        1.97888389e-04, -1.23435636e-03, -7.56440358e-04, -2.97200186e-03, -1.34446557e-03, 8.17779135e-04, 2.52697129e-03, 1.52477197e-02,

--- a/antropy/utils.py
+++ b/antropy/utils.py
@@ -4,6 +4,7 @@ from numba import jit
 from math import log, floor
 
 all = ['_embed', '_linear_regression', '_log_n', '_xlog2x']
+epsilon = 10e-9
 
 
 def _embed(x, order=3, delay=1):
@@ -85,7 +86,7 @@ def _linear_regression(x, y):
         sy += y[j]
     den = n_times * sx2 - (sx ** 2)
     num = n_times * sxy - sx * sy
-    slope = num / den
+    slope = num / (den + epsilon)
     intercept = np.mean(y) - slope * np.mean(x)
     return slope, intercept
 

--- a/antropy/utils.py
+++ b/antropy/utils.py
@@ -4,7 +4,7 @@ from numba import jit
 from math import log, floor
 
 all = ['_embed', '_linear_regression', '_log_n', '_xlog2x']
-epsilon = 10e-9
+# epsilon = 10e-9
 
 
 def _embed(x, order=3, delay=1):
@@ -86,7 +86,7 @@ def _linear_regression(x, y):
         sy += y[j]
     den = n_times * sx2 - (sx ** 2)
     num = n_times * sxy - sx * sy
-    slope = num / (den + epsilon)
+    slope = num / den
     intercept = np.mean(y) - slope * np.mean(x)
     return slope, intercept
 

--- a/antropy/utils.py
+++ b/antropy/utils.py
@@ -4,7 +4,7 @@ from numba import jit
 from math import log, floor
 
 all = ['_embed', '_linear_regression', '_log_n', '_xlog2x']
-# epsilon = 10e-9
+epsilon = 10e-9
 
 
 def _embed(x, order=3, delay=1):
@@ -86,7 +86,7 @@ def _linear_regression(x, y):
         sy += y[j]
     den = n_times * sx2 - (sx ** 2)
     num = n_times * sxy - sx * sy
-    slope = num / den
+    slope = num / (den + epsilon)
     intercept = np.mean(y) - slope * np.mean(x)
     return slope, intercept
 


### PR DESCRIPTION
I have been facing problems when computing the Detrended fluctuation analysis (DFA) using the `function detrended_fluctuation(x)` and the input array is relatively small (subwindows of windows). 

In some cases, **_len(fluctuations)=1_** causing _den=0_ in the linear regression function. This fix solves the issue for me, having expected results.

