### PR TITLE
Allow readonly arrays in numba jit signature

### DIFF
--- a/antropy/entropy.py
+++ b/antropy/entropy.py
@@ -1,6 +1,6 @@
 """Entropy functions"""
 import numpy as np
-from numba import jit
+from numba import jit, types
 from math import factorial, log
 from sklearn.neighbors import KDTree
 from scipy.signal import periodogram, welch
@@ -408,7 +408,7 @@ def _app_samp_entropy(x, order, metric="chebyshev", approximate=True):
     return phi
 
 
-@jit("f8(f8[:], i4, f8)", nopython=True)
+@jit((types.Array(types.float64, 1, "C", readonly=True), types.int32, types.float64), nopython=True)
 def _numba_sampen(x, order, r):
     """
     Fast evaluation of the sample entropy using Numba.

--- a/antropy/fractal.py
+++ b/antropy/fractal.py
@@ -299,7 +299,7 @@ def higuchi_fd(x, kmax=10):
     return _higuchi_fd(x, kmax)
 
 
-@jit("f8(f8[:])", nopython=True)
+@jit((types.Array(types.float64, 1, "C", readonly=True),), nopython=True)
 def _dfa(x):
     """
     Utility function for detrended fluctuation analysis

--- a/antropy/fractal.py
+++ b/antropy/fractal.py
@@ -194,7 +194,7 @@ def katz_fd(x, axis=-1):
     return kfd
 
 
-@jit((types.Array(types.float64, 1, "C", readonly=True), types.int32))
+@jit((types.Array(types.float64, 1, "C", readonly=True), types.int32), nopython=True)
 def _higuchi_fd(x, kmax):
     """Utility function for `higuchi_fd`."""
     n_times = x.size

--- a/antropy/tests/test_entropy.py
+++ b/antropy/tests/test_entropy.py
@@ -143,7 +143,7 @@ class TestEntropy(unittest.TestCase):
             aal(hjorth_params, axis=-1, arr=data[:-1, :]).T,
             hjorth_params(data[:-1, :], axis=-1),
         )
-    
+
     def test_notwritable_dtypes(self):
         entropy_funcs = [
             perm_entropy,

--- a/antropy/tests/test_entropy.py
+++ b/antropy/tests/test_entropy.py
@@ -16,14 +16,10 @@ from antropy import (
 
 from antropy.utils import _xlogx
 
-np.random.seed(1234567)
-RANDOM_TS = np.random.rand(3000)
-NORMAL_TS = np.random.normal(size=3000)
-RANDOM_TS_LONG = np.random.rand(6000)
+from utils import RANDOM_TS, NORMAL_TS, RANDOM_TS_LONG, PURE_SINE, ARANGE, TEST_DTYPES
+
 SF_TS = 100
 BANDT_PERM = [4, 7, 9, 10, 6, 11, 3]
-PURE_SINE = np.sin(2 * np.pi * 1 * np.arange(3000) / 100)
-ARANGE = np.arange(3000)
 
 # Concatenate 2D data
 data = np.vstack((RANDOM_TS, NORMAL_TS, PURE_SINE, ARANGE))
@@ -147,6 +143,24 @@ class TestEntropy(unittest.TestCase):
             aal(hjorth_params, axis=-1, arr=data[:-1, :]).T,
             hjorth_params(data[:-1, :], axis=-1),
         )
+    
+    def test_notwritable_dtypes(self):
+        entropy_funcs = [
+            perm_entropy,
+            lambda x: spectral_entropy(x, sf=100),  # sf is required arg
+            svd_entropy,
+            sample_entropy,
+            app_entropy,
+            lziv_complexity,
+            num_zerocross,
+            hjorth_params,
+        ]
+        # Make sure that the functions can handle non-writable arrays
+        for func in entropy_funcs:
+            for dtype in TEST_DTYPES:
+                x = RANDOM_TS.astype(dtype)
+                x.flags.writeable = False
+                func(x)
 
     def test_xlogx_handles_zero(self):
         assert_equal(_xlogx(0), 0)

--- a/antropy/tests/test_fractal.py
+++ b/antropy/tests/test_fractal.py
@@ -5,13 +5,9 @@ from numpy.testing import assert_equal
 from numpy import apply_along_axis as aal
 from antropy import petrosian_fd, katz_fd, higuchi_fd, detrended_fluctuation
 
-np.random.seed(1234567)
-RANDOM_TS = np.random.rand(3000)
-NORMAL_TS = np.random.normal(size=3000)
-RANDOM_TS_LONG = np.random.rand(6000)
-SF_TS = 100
-PURE_SINE = np.sin(2 * np.pi * 1 * np.arange(3000) / 100)
-ARANGE = np.arange(3000)
+
+from utils import RANDOM_TS, NORMAL_TS, PURE_SINE, ARANGE, TEST_DTYPES
+
 PPG_SIGNAL = np.array(
     [
         -4.18272436e-07,
@@ -68,10 +64,6 @@ class TestEntropy(unittest.TestCase):
         """
         # Compare with MNE-features
         self.assertEqual(np.round(higuchi_fd(RANDOM_TS), 8), 1.9914198)
-        # Check if readonly arrays can be processed as well
-        x = RANDOM_TS.copy().astype(np.float64)
-        x.flags.writeable = False
-        self.assertEqual(np.round(higuchi_fd(x), 8), 1.9914198)
         higuchi_fd(list(RANDOM_TS), kmax=20)
 
     def test_detrended_fluctuation(self):
@@ -84,3 +76,12 @@ class TestEntropy(unittest.TestCase):
         self.assertEqual(np.round(detrended_fluctuation(RANDOM_TS), 4), 0.4976)
         self.assertEqual(np.round(detrended_fluctuation(PURE_SINE), 4), 1.5848)
         self.assertEqual(np.round(detrended_fluctuation(PPG_SIGNAL), 4), 0.0)
+
+    def test_notwritable_dtypes(self):
+        fractal_funcs = [petrosian_fd, katz_fd, higuchi_fd, detrended_fluctuation]
+        # Make sure that the functions can handle non-writable arrays
+        for func in fractal_funcs:
+            for dtype in TEST_DTYPES:
+                x = RANDOM_TS.astype(dtype)
+                x.flags.writeable = False
+                func(x)

--- a/antropy/tests/utils.py
+++ b/antropy/tests/utils.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+np.random.seed(1234567)
+RANDOM_TS = np.random.rand(3000)
+NORMAL_TS = np.random.normal(size=3000)
+RANDOM_TS_LONG = np.random.rand(6000)
+PURE_SINE = np.sin(2 * np.pi * 1 * np.arange(3000) / 100)
+ARANGE = np.arange(3000)
+
+# Data types for which to test input array compatibility
+TEST_DTYPES = [
+    np.float16, np.float32, np.float64,         # floats
+    np.int8, np.int16, np.int32, np.int64,      # ints
+    np.uint8, np.uint16, np.uint32, np.uint64,  # unsigned ints
+]

--- a/antropy/tests/utils.py
+++ b/antropy/tests/utils.py
@@ -9,7 +9,18 @@ ARANGE = np.arange(3000)
 
 # Data types for which to test input array compatibility
 TEST_DTYPES = [
-    np.float16, np.float32, np.float64,         # floats
-    np.int8, np.int16, np.int32, np.int64,      # ints
-    np.uint8, np.uint16, np.uint32, np.uint64,  # unsigned ints
+    # floats
+    np.float16,
+    np.float32,
+    np.float64,
+    np.int8,
+    # ints
+    np.int16,
+    np.int32,
+    np.int64,
+    # unsigned ints
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
 ]


### PR DESCRIPTION
This PR is a continuation of the work contributed in PR #13 

Contributions of this PR:
- [x] allow readonly arrays in the numba jit signature
-> this was an issue for `sample_entropy` and `detrended_fluctuation`
- [x] minor refactoring of the tests - moving duplicate code to a `utils.py` file
- [x] adding 2 additional tests that test whether non-writable (i.e., readonly) arrays can be used as input for a range of datatypes

Other contribution:
- [x] set `nopython` to True for the `_higuchi_fd` function - this was the only `@jit` decorated function for which this flag was not set.

---

Illustration of the issue that this PR tackles:
```py
In [1]: import antropy as ant; import numpy as np

In [2]: ant.__version__
Out[2]: '0.1.5'

In [3]: x = np.random.randn(3_000).astype("float32")
   ...: x.flags.writeable = False
   ...: ant.detrended_fluctuation(x)
Out[3]: 0.5552594723035992

In [4]: x = np.random.randn(3_000).astype("float64")
   ...: x.flags.writeable = False
   ...: ant.detrended_fluctuation(x)
---------------------------------------------------------------------------
TypeError
    ...
TypeError: No matching definition for argument type(s) readonly array(float64, 1d, C)

In [5]: x = np.random.rand(3_000).astype("float32")
   ...: x.flags.writeable = False
   ...: ant.sample_entropy(x)
Out[5]: 2.17591547251706

In [6]: x = np.random.rand(3_000).astype("float64")
   ...: x.flags.writeable = False
   ...: ant.sample_entropy(x)
---------------------------------------------------------------------------
TypeError
    ...
TypeError: No matching definition for argument type(s) readonly array(float64, 1d, C), int64, float64

```
 