### PR TITLE
fix: `KDTree.valid_metrics` is method since sklearn 1.3

### DIFF
--- a/antropy/entropy.py
+++ b/antropy/entropy.py
@@ -373,6 +373,7 @@ def svd_entropy(x, order=3, delay=1, normalize=False):
 def _app_samp_entropy(x, order, metric="chebyshev", approximate=True):
     """Utility function for `app_entropy`` and `sample_entropy`."""
     _all_metrics = KDTree.valid_metrics
+    _all_metrics = _all_metrics() if callable(_all_metrics) else _all_metrics
     if metric not in _all_metrics:
         raise ValueError(
             "The given metric (%s) is not valid. The valid "


### PR DESCRIPTION
This PR introduces a check for `KDTree.valid_metrics`, which has been converted to a method in sklearn version 1.3. 
The code now verifies if this is a callable, and if so the method is called (the check still supports the older behavior of sklearn, where this was not a method).



