### PR TITLE
update SampEn and AppEn to allow for variable tolerance values

### DIFF
--- a/antropy/entropy.py
+++ b/antropy/entropy.py
@@ -380,8 +380,6 @@ def _app_samp_entropy(x, order, r, metric="chebyshev", approximate=True):
             "metric names are: %s" % (metric, _all_metrics)
         )
     phi = np.zeros(2)
-    
-
 
     # compute phi(order, r)
     _emb_data1 = _embed(x, order, 1)
@@ -467,7 +465,7 @@ def app_entropy(x, order=2, tolerance=None, metric="chebyshev"):
         Embedding dimension. Default is 2.
     tolerance : float
         Tolerance value for acceptance of the template vector. Default is 0.2
-        times the standard deviation of x. 
+        times the standard deviation of x.
     metric : str
         Name of the distance metric function used with
         :py:class:`sklearn.neighbors.KDTree`. Default is to use the
@@ -555,6 +553,7 @@ def app_entropy(x, order=2, tolerance=None, metric="chebyshev"):
     phi = _app_samp_entropy(x, order=order, r=r, metric=metric, approximate=True)
     return np.subtract(phi[0], phi[1])
 
+
 def sample_entropy(x, order=2, tolerance=None, metric="chebyshev"):
     """Sample Entropy.
 
@@ -566,7 +565,7 @@ def sample_entropy(x, order=2, tolerance=None, metric="chebyshev"):
         Embedding dimension. Default is 2.
     tolerance : float
         Tolerance value for acceptance of the template vector. Default is 0.2
-        times the standard deviation of x. 
+        times the standard deviation of x.
     metric : str
         Name of the distance metric function used with
         :py:class:`sklearn.neighbors.KDTree`. Default is to use the

--- a/antropy/entropy.py
+++ b/antropy/entropy.py
@@ -370,7 +370,7 @@ def svd_entropy(x, order=3, delay=1, normalize=False):
     return svd_e
 
 
-def _app_samp_entropy(x, order, metric="chebyshev", approximate=True):
+def _app_samp_entropy(x, order, r, metric="chebyshev", approximate=True):
     """Utility function for `app_entropy`` and `sample_entropy`."""
     _all_metrics = KDTree.valid_metrics
     _all_metrics = _all_metrics() if callable(_all_metrics) else _all_metrics
@@ -380,7 +380,8 @@ def _app_samp_entropy(x, order, metric="chebyshev", approximate=True):
             "metric names are: %s" % (metric, _all_metrics)
         )
     phi = np.zeros(2)
-    r = 0.2 * np.std(x, ddof=0)
+    
+
 
     # compute phi(order, r)
     _emb_data1 = _embed(x, order, 1)
@@ -390,14 +391,14 @@ def _app_samp_entropy(x, order, metric="chebyshev", approximate=True):
         emb_data1 = _emb_data1[:-1]
     count1 = (
         KDTree(emb_data1, metric=metric)
-        .query_radius(emb_data1, r, count_only=True)
+        .query_radius(emb_data1, tolerance, count_only=True)
         .astype(np.float64)
     )
     # compute phi(order + 1, r)
     emb_data2 = _embed(x, order + 1, 1)
     count2 = (
         KDTree(emb_data2, metric=metric)
-        .query_radius(emb_data2, r, count_only=True)
+        .query_radius(emb_data2, tolerance, count_only=True)
         .astype(np.float64)
     )
     if approximate:
@@ -455,7 +456,7 @@ def _numba_sampen(sequence, order, r):
         return -log(numerator / denominator)
 
 
-def app_entropy(x, order=2, metric="chebyshev"):
+def app_entropy(x, order=2, tolerance=0.2, metric="chebyshev", tolerance_reference="SD"):
     """Approximate Entropy.
 
     Parameters
@@ -464,12 +465,17 @@ def app_entropy(x, order=2, metric="chebyshev"):
         One-dimensional time series of shape (n_times).
     order : int
         Embedding dimension. Default is 2.
+    tolerance : float
+        Tolerance value for acceptance of template vector. Default is 0.2
+        times the standard deviation. 
     metric : str
         Name of the distance metric function used with
         :py:class:`sklearn.neighbors.KDTree`. Default is to use the
         `Chebyshev <https://en.wikipedia.org/wiki/Chebyshev_distance>`_
         distance.
-
+    tolerance_reference : str
+        Switch between tolerance value relative to standard deviation (`SD`)
+        and absolute values (`abs`). Default is `SD`. 
     Returns
     -------
     ae : float
@@ -481,7 +487,7 @@ def app_entropy(x, order=2, metric="chebyshev"):
     regularity and the unpredictability of fluctuations over time-series data.
     Smaller values indicates that the data is more regular and predictable.
 
-    The tolerance value (:math:`r`) is set to :math:`0.2 * \\text{std}(x)`.
+    The default tolerance value (:math:`r`) is set to :math:`0.2 * \\text{std}(x)`.
 
     Code adapted from the `mne-features <https://mne.tools/mne-features/>`_
     package by Jean-Baptiste Schiratti and Alexandre Gramfort.
@@ -543,11 +549,20 @@ def app_entropy(x, order=2, metric="chebyshev"):
     >>> print(f"{ant.app_entropy(x):.4f}")
     -0.0010
     """
-    phi = _app_samp_entropy(x, order=order, metric=metric, approximate=True)
+    # define r
+    if tolerance_reference =="SD":
+        r = tolerance * np.std(x, ddof=0)
+    elif tolerance_reference == "abs":
+        r = tolerance
+    else:
+        raise ValueError(
+            "The given reference for the tolerance r of %s is not valid."
+            "The valid options are: SD and abs" %(tolerance_reference)
+        )
+    phi = _app_samp_entropy(x, order=order, r=r, metric=metric, approximate=True)
     return np.subtract(phi[0], phi[1])
 
-
-def sample_entropy(x, order=2, metric="chebyshev"):
+def sample_entropy(x, order=2, tolerance=0.2, metric="chebyshev", tolerance_reference="SD"):
     """Sample Entropy.
 
     Parameters
@@ -652,11 +667,21 @@ def sample_entropy(x, order=2, metric="chebyshev"):
     >>> print(f"{ant.sample_entropy(x):.4f}")
     -0.0000
     """
+    # define r
+    if tolerance_reference =="SD":
+        r = tolerance * np.std(x, ddof=0)
+    elif tolerance_reference == "abs":
+        r = tolerance
+    else:
+        raise ValueError(
+            "The given reference for the tolerance r of %s is not valid."
+            "The valid options are: SD and abs" %(tolerance_reference)
+        )
     x = np.asarray(x, dtype=np.float64)
     if metric == "chebyshev" and x.size < 5000:
-        return _numba_sampen(x, order=order, r=(0.2 * x.std(ddof=0)))
+        return _numba_sampen(x, order=order, r=r)
     else:
-        phi = _app_samp_entropy(x, order=order, metric=metric, approximate=False)
+        phi = _app_samp_entropy(x, order=order, r=r, metric=metric, approximate=False)
         return -np.log(np.divide(phi[1], phi[0]))
 
 

--- a/antropy/entropy.py
+++ b/antropy/entropy.py
@@ -467,7 +467,7 @@ def app_entropy(x, order=2, tolerance=None, metric="chebyshev"):
         Embedding dimension. Default is 2.
     tolerance : float
         Tolerance value for acceptance of the template vector. Default is 0.2
-        times the standard deviation. 
+        times the standard deviation of x. 
     metric : str
         Name of the distance metric function used with
         :py:class:`sklearn.neighbors.KDTree`. Default is to use the
@@ -550,6 +550,7 @@ def app_entropy(x, order=2, tolerance=None, metric="chebyshev"):
     if tolerance is None:
         r = 0.2 * np.std(x, ddof=0)
     else:
+        assert isinstance(tolerance, (float, int))
         r = tolerance
     phi = _app_samp_entropy(x, order=order, r=r, metric=metric, approximate=True)
     return np.subtract(phi[0], phi[1])
@@ -565,7 +566,7 @@ def sample_entropy(x, order=2, tolerance=None, metric="chebyshev"):
         Embedding dimension. Default is 2.
     tolerance : float
         Tolerance value for acceptance of the template vector. Default is 0.2
-        times the standard deviation. 
+        times the standard deviation of x. 
     metric : str
         Name of the distance metric function used with
         :py:class:`sklearn.neighbors.KDTree`. Default is to use the
@@ -666,6 +667,7 @@ def sample_entropy(x, order=2, tolerance=None, metric="chebyshev"):
     if tolerance is None:
         r = 0.2 * np.std(x, ddof=0)
     else:
+        assert isinstance(tolerance, (float, int))
         r = tolerance
     x = np.asarray(x, dtype=np.float64)
     if metric == "chebyshev" and x.size < 5000:


### PR DESCRIPTION
Extension of the SampEn and AppEn functions in order to be able to flexibly set the respective tolerance r. By default, the value is set relative to the standard deviation, but it is also possible to specify an absolute value. 

PR refers to #31