### PR TITLE
MAINT: Remove stochastic hard dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,6 @@ To build and install from source, clone this repository or download the source a
 - `scipy <https://www.scipy.org/>`_
 - `scikit-learn <https://scikit-learn.org/>`_
 - `numba <http://numba.pydata.org/>`_
-- `stochastic <https://github.com/crflynn/stochastic>`_
 
 Functions
 =========

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "scipy",
     "scikit-learn",
     "numba>=0.57",
-    "stochastic",
 ]
 
 [project.optional-dependencies]
@@ -48,6 +47,7 @@ docs = [
     "numpydoc",
     "sphinx-copybutton",
     "sphinx-design",
+    "stochastic",  # for doctests
     # "sphinx-notfound-page",
 ]
 


### PR DESCRIPTION
Closes #40

Looks like it's only needed for doctests, so move to `doc` dependency where I think it will be used