### PR TITLE
 CI: deploy documentation to GitHub Pages via GitHub Actions   

### DIFF
--- a/.github/workflows/deploy_doc.yml
+++ b/.github/workflows/deploy_doc.yml
@@ -1,0 +1,51 @@
+name: Deploy Documentation to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+# Cancel any in-progress job or run
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    env:
+      FORCE_COLOR: true
+      UV_SYSTEM_PYTHON: 1
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: "pyproject.toml"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        run: uv pip install --group=docs --editable .
+
+      - name: Build documentation
+        run: |
+          make -C docs clean
+          make -C docs html
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/build/html
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,38 @@
+name: Build documentation and upload as artifact to GitHub Actions
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: true
+      UV_SYSTEM_PYTHON: 1
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: "pyproject.toml"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        run: uv pip install --group=docs --editable .
+
+      - name: Build documentation
+        run: |
+          make -C docs clean
+          make -C docs html
+
+      - name: Upload documentation artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: docs-artifact
+          path: docs/build/html

--- a/.gitignore
+++ b/.gitignore
@@ -102,7 +102,7 @@ venv.bak/
 # mypy
 .mypy_cache/
 desktop.ini
-docs/build/doctrees/
+docs/build/
 docs/generated/
 .DS_Store
 push_pypi.md

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -48,6 +48,34 @@ Submitting a pull request
 
 6. Open a pull request against the ``master`` branch.
 
+Updating the documentation
+--------------------------
+
+The documentation is built with `Sphinx <https://www.sphinx-doc.org/>`_. To build it locally:
+
+1. Install the documentation dependencies:
+
+   .. code-block:: shell
+
+       uv pip install --group=docs --editable .
+
+2. Build the HTML docs:
+
+   .. code-block:: shell
+
+       make -C docs clean
+       make -C docs html
+
+3. Open ``docs/build/html/index.html`` in your browser to preview the result.
+
+When you open a pull request, a ``docs`` CI job automatically builds the documentation and
+uploads the result as a GitHub Actions artifact. To verify the rendered docs from a PR:
+
+1. Go to the PR on GitHub and click on the **Checks** tab.
+2. Open the **Build documentation and upload as artifact to GitHub Actions** workflow run.
+3. Click **Summary** in the left sidebar, then scroll down to the **Artifacts** section.
+4. Download the ``docs-artifact`` zip file and open ``index.html`` in your browser.
+
 Questions
 ---------
 


### PR DESCRIPTION
Replaces the branch-based GitHub Pages deployment (master / docs/) with GitHub Actions workflows.

**Changes:**
  - Add `deploy_doc.yml` — builds and deploys docs to GitHub Pages on every push to master (requires setting Pages source to "GitHub Actions" in repo settings)
  - Add `docs.yml` — builds docs and uploads as a downloadable artifact on every push/PR to master, for preview without deploying
  - Update `.gitignore` to ignore all of `docs/build/` (previously only `docs/build/doctrees/`)
  - Add "Updating the documentation" section to `contributing.rst `with local build instructions and a guide to verifying the doc artifact from a PR