### PR TITLE
FIX: correct off-by-one in Higuchi FD inner loop

### DIFF
--- a/src/antropy/fractal.py
+++ b/src/antropy/fractal.py
@@ -212,7 +212,7 @@ def _higuchi_fd(x, kmax):
             ll = 0
             n_max = floor((n_times - m - 1) / k)
             n_max = int(n_max)
-            for j in range(1, n_max):
+            for j in range(1, n_max + 1):
                 ll += abs(x[m + j * k] - x[m + (j - 1) * k])
             ll /= k
             ll *= (n_times - 1) / (k * n_max)
@@ -254,7 +254,7 @@ def higuchi_fd(x, kmax=10):
     .. math::
 
         L_m(k) = \\frac{N-1}{k^2 \\cdot N_m}
-        \\sum_{j=1}^{N_m - 1} |x_{m+jk} - x_{m+(j-1)k}|
+        \\sum_{j=1}^{N_m} |x_{m+jk} - x_{m+(j-1)k}|
 
     and the average length across all :math:`k` sub-series is:
 
@@ -291,39 +291,39 @@ def higuchi_fd(x, kmax=10):
     >>> rng = np.random.default_rng(seed=42)
     >>> x = sn.FractionalGaussianNoise(hurst=0.5, rng=rng).sample(10000)
     >>> print(f"{ant.higuchi_fd(x):.4f}")
-    1.9983
+    1.9980
 
     Fractional Gaussian noise with H = 0.9
 
     >>> rng = np.random.default_rng(seed=42)
     >>> x = sn.FractionalGaussianNoise(hurst=0.9, rng=rng).sample(10000)
     >>> print(f"{ant.higuchi_fd(x):.4f}")
-    1.8517
+    1.8512
 
     Fractional Gaussian noise with H = 0.1
 
     >>> rng = np.random.default_rng(seed=42)
     >>> x = sn.FractionalGaussianNoise(hurst=0.1, rng=rng).sample(10000)
     >>> print(f"{ant.higuchi_fd(x):.4f}")
-    2.0581
+    2.0575
 
     Random
 
     >>> rng = np.random.default_rng(seed=42)
     >>> print(f"{ant.higuchi_fd(rng.random(1000)):.4f}")
-    2.0013
+    1.9975
 
     Pure sine wave
 
     >>> x = np.sin(2 * np.pi * 1 * np.arange(3000) / 100)
     >>> print(f"{ant.higuchi_fd(x):.4f}")
-    1.0091
+    1.0074
 
     Linearly-increasing time-series
 
     >>> x = np.arange(1000)
     >>> print(f"{ant.higuchi_fd(x):.4f}")
-    1.0040
+    1.0000
     """
     x = np.asarray(x, dtype=np.float64)
     kmax = int(kmax)

--- a/tests/test_fractal.py
+++ b/tests/test_fractal.py
@@ -65,7 +65,7 @@ class TestEntropy(unittest.TestCase):
         Results have been tested against the MNE-features and pyrem packages.
         """
         # Compare with MNE-features
-        self.assertEqual(np.round(higuchi_fd(RANDOM_TS), 8), 1.9914198)
+        self.assertEqual(np.round(higuchi_fd(RANDOM_TS), 8), 1.99030363)
         higuchi_fd(list(RANDOM_TS), kmax=20)
 
     def test_detrended_fluctuation(self):


### PR DESCRIPTION
The inner loop summed `j = 1 … N_m-1` (n_max-1 terms) instead of the correct `j = 1 … N_m` (n_max terms), dropping the last difference in each sub-series and slightly underestimating curve length.

Fix: `range(1, n_max)` → `range(1, n_max + 1)`

Also corrects the docstring formula (upper limit `N_m-1` → `N_m`) and updates all higuchi_fd docstring examples and the unit test expected value to match the corrected output.