### PR TITLE
MAINT: Fix imports and clean up project configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,15 +5,7 @@ For the full list of built-in configuration values, see the documentation:
 https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
 
-import os
-import sys
-
 import antropy
-
-# -- Path setup --------------------------------------------------------------
-
-sys.path.insert(0, os.path.abspath(os.path.pardir))
-
 
 # -- Project information -----------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 [dependency-groups]
 dev = ["ruff>=0.9"]
 test = [
-    "pytest>=6",
+    "pytest>=7.0",
     "pytest-cov",
     # Ensure coverage is new enough for `source_pkgs`.
     "coverage[toml]>=5.3",
@@ -54,7 +54,6 @@ Homepage = "https://github.com/raphaelvallat/antropy/"
 Downloads = "https://github.com/raphaelvallat/antropy/"
 
 [tool.setuptools]
-py-modules = ["antropy"]
 include-package-data = false
 
 [tool.setuptools.packages.find]
@@ -65,8 +64,10 @@ where = ["src"]
 version = {attr = "antropy.__version__"}
 
 [tool.pytest.ini_options]
-minversion = "6.0"
+minversion = "7.0"
 addopts = "--showlocals --durations=10"  # --cov
+testpaths = ["tests"]
+pythonpath = ["tests"]
 doctest_optionflags= ["NORMALIZE_WHITESPACE", "IGNORE_EXCEPTION_DETAIL"]
 filterwarnings = [
     "ignore::UserWarning",


### PR DESCRIPTION
- Remove dead sys.path.insert in docs/conf.py (ran after import antropy, so had no effect)                                                                 
- Remove incorrect py-modules = ["antropy"] from pyproject.toml (for single-file modules only; package discovery via packages.find was already correct)
- Add explicit testpaths and pythonpath = ["tests"] to pytest config, replacing the implicit sys.path injection that made from utils import work in test   
files                                                     
- Bump minimum pytest to 7.0 (required for pythonpath ini option)
